### PR TITLE
GitHub Pages に自動デプロイ可能にする

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,5 +66,5 @@ jobs:
       - name: Deploy GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
-          deploy_key: ${{ secrets.GITHUB_TOKEN }}
+          deploy_key: ${{ secrets.GH_ACTIONS_DEPLOY_SECRET_KEY }}
           publish_dir: ./dist

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,6 +66,5 @@ jobs:
       - name: Deploy GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
-          # deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          deploy_key: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,6 @@ name: Deploy GitHub Pages
 on:
   push:
     branches: [feature/pipeline]
-# on: [push]
 
 jobs:
   # 製品のテストを実施

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy GitHub Pages
 # masterブランチへのpushをトリガーとして実行
 on:
   push:
-    branches: [feature/pipeline]
+    branches: [master]
 
 jobs:
   # 製品のテストを実施

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,71 @@
+name: Deploy GitHub Pages
+
+# masterブランチへのpushをトリガーとして実行
+on:
+  push:
+    branches: [master]
+# on: [push]
+
+jobs:
+  # 製品のテストを実施
+  test:
+    name: 'Test product'
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      # 作業用の環境を整える
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      # 必要なパッケージ群をインストールする
+      - name: Install packages
+        run: npm ci
+
+      # テスト実施
+      - name: Test
+        run: npm run test
+
+  # テスト完了後、リリースを実施
+  deploy:
+    name: 'Deploy product'
+    needs: [test]
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      # 作業用の環境を整える
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      # 必要なパッケージ群をインストールする
+      - name: Install packages
+        run: npm ci
+
+      # GitHub Pages用のファイルを生成する
+      - name: Generate product
+        run: npm run generate
+        env:
+          DEPLOY_ENV: GH_PAGES
+
+      # dist配下に生成されたファイルをGitHub Pagesにデプロイする
+      - name: Deploy GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          # deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy GitHub Pages
 # masterブランチへのpushをトリガーとして実行
 on:
   push:
-    branches: [master]
+    branches: [feature/pipeline]
 # on: [push]
 
 jobs:

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -3,7 +3,10 @@ export default {
    ** Nuxt rendering mode
    ** See https://nuxtjs.org/api/configuration-mode
    */
-  mode: 'universal',
+  mode: 'spa',
+  router: {
+    base: process.env.DEPLOY_ENV === 'GH_PAGES' ? '/ir_graph/' : '/',
+  },
   /*
    ** Nuxt target
    ** See https://nuxtjs.org/api/configuration-target
@@ -14,6 +17,10 @@ export default {
    ** See https://nuxtjs.org/api/configuration-head
    */
   head: {
+    base: {
+      // GitHub Pages のサブディレクトリで運用するため
+      href: 'router.base',
+    },
     title: process.env.npm_package_name || '',
     meta: [
       { charset: 'utf-8' },
@@ -24,7 +31,16 @@ export default {
         content: process.env.npm_package_description || '',
       },
     ],
-    link: [{ rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }],
+    link: [
+      {
+        rel: 'icon',
+        type: 'image/x-icon',
+        href:
+          process.env.DEPLOY_ENV === 'GH_PAGES'
+            ? '/ir_graph/favicon.ico'
+            : '/favicon.ico',
+      },
+    ],
   },
   /*
    ** Global CSS

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "serve": "nuxt serve",
     "lint:js": "eslint --ext .js,.vue --ignore-path .gitignore .",
     "lint": "npm run lint:js",
-    "test": "jest"
+    "test": "jest",
+    "generate": "nuxt generate"
   },
   "dependencies": {
     "@nuxtjs/axios": "^5.11.0",


### PR DESCRIPTION
## 概要
#4 

## 実装内容
* `package.json`にデプロイ用のコマンドを作成
* `ir_graph`配下のディレクトリでデプロイできるように、`nuxt.config.js`を修正
* GitHub Actionsのファイルを作成
* GitHub Actionsで利用するデプロイ用のキーを作成、登録
`ssh-keygen -t rsa -b 4096 -C "$(git config user.email)" -f my-repo -N ""`で生成可能
* 公開鍵をDeploy keysに登録
* 書き込み権限を付与すること
* 秘密鍵をSecretsに登録
* Secretsに登録した名前を、github workflowで利用することになる
* `gh-pages`ブランチを新規作成
* publicリポジトリとする

## 残りタスク
- [x] デプロイ用のシークレットキーの作成と登録
- [ ] ブランチ名を`master`に戻す

## 参考
[GitHubPagesのデプロイキー作成・登録](https://sphinx-users.jp/cookbook/githubaction/index.html)